### PR TITLE
accept unknown in logger error and add toError helper

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "name": "API Helpers - Jest",
       "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
       "args": ["--verbose", "-i", "--no-cache"],
-      "runtimeExecutable": "${env:HOME}/.nvm/versions/node/v20.15.1/bin/node",
+      "runtimeExecutable": "${env:NVM_DIR}/versions/node/v20.15.1/bin/node",
       "sourceMaps": true,
       "cwd": "${workspaceRoot}",
       "console": "integratedTerminal"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,20 @@
 {
-    "css.validate": false,
-    "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": "explicit"
-    },
-    "eslint.validate": [
-        "javascript"
-    ],
-    "git.autofetch": true,
-    "stylelint.config": null,
-    "stylelint.validate": [ "css", "scss"]
+  "css.validate": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.validate": [
+    "javascript",
+    "typescript"
+  ],
+  "git.autofetch": true,
+  "stylelint.config": null,
+  "stylelint.validate": [
+    "css",
+    "scss"
+  ],
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": false
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,143 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repository is
+
+A private, internal NestJS support library (`mind-api-helpers`) shared by the `mind-api-*` /
+`multi-api-*` services. It ships no application, no `main.ts` and no HTTP server — only the logger,
+the GraphQL bootstrap services, the error helpers and the Mongoose query builder that those services
+import.
+
+Everything public goes through the barrel `src/index.ts`. A new file is invisible to consumers until
+it is re-exported there.
+
+## Commands
+
+Node is pinned by `.nvmrc` (v20.15.1) and the package manager is **yarn** (v1 / classic).
+
+```bash
+nvm use                                   # required: the lockfile and the launch.json path assume v20
+yarn install                              # see the install cycle warning below
+yarn build                                # tsc -> dist/ (prebuild wipes dist via rimraf)
+yarn lint                                 # eslint (prettier runs as an eslint rule)
+yarn lint-autofix
+yarn test                                 # jest, config in jest.config.json, testRegex .spec.ts$
+yarn test src/mind-helpers               # one directory
+yarn test -t 'should preserve subclasses' # one test by name
+```
+
+There is no watch/coverage script; use `yarn test --watch` / `--coverage` directly. `.vscode/launch.json`
+provides an "API Helpers - Jest" debug configuration (hardcoded to `$NVM_DIR/versions/node/v20.15.1`).
+
+## How this library is distributed
+
+Consumers depend on the **git URL pinned to a tag**, not on a registry:
+
+```json
+"mind-api-helpers": "https://github.com/Multiplan-MIND/mind-api-helpers.git#1.3.0"
+```
+
+`dist/` is gitignored, so the consumer has to build the package after cloning it. That is what the
+install cycle in `package.json` is for, and it is the reason the dependency layout looks wrong:
+
+- `preinstall: yarn --ignore-scripts` — installs the dependency tree, `devDependencies` included, so
+  `typescript` exists inside the consumer's `node_modules/mind-api-helpers`.
+- `postinstall: yarn build` — compiles `src/` to `dist/`, which `main`/`types` point at.
+
+Consequences to keep in mind when touching `package.json`:
+
+- Almost everything `src/` imports at **runtime** (`mongoose`, `ioredis`, `jsonwebtoken`, `jwk-to-pem`,
+  `graphql-type-json`, `winston`, `nest-winston`, `@nestjs/*`, `@apollo/server`) sits in
+  `devDependencies`; only `@nestjs/common` and `winston` are declared as peers. At runtime these
+  resolve from the **consumer's** `node_modules`, so a version bump here can silently disagree with
+  what the services install.
+- `axios` — imported by `error.helper.ts` and `graphql-auth-jwks.service.ts` — is not declared at all.
+  It only reaches `node_modules` because the single entry in `dependencies`, the deprecated
+  `@types/axios@0.14.0` stub, depends on `axios: "*"`.
+- Releasing means bumping `version` in `package.json`, tagging the commit, and updating the `#tag` in
+  each consuming repo. Branches are used as refs too (`#feature/to-error-helper`) while a change is
+  being validated against a service.
+
+## Architecture
+
+Dependency direction is one-way: `mind-helpers` ← `mind-logger` ← `mind-graphql` / `mind-mongoose`.
+`mind-helpers` imports nothing internal, so it is the safe place for shared primitives.
+
+### `mind-logger` — the decorator/registry pattern
+
+The unusual part: **module names are collected at decoration time and turned into providers later.**
+
+1. `@MindLogger('SomeService')` (`mind-logger.decorator.ts`) pushes the name into the module-level
+   array `modulesForLoggers` and returns `Inject('MindLoggerService<name>')`.
+2. `MindLoggerModule.forRoot()` calls `createMindLoggerProviders()`, which maps that array into one
+   provider per name, each a factory that calls `logger.setModule(name)`.
+
+So `forRoot()` only sees a name if the class carrying the decorator has already been imported when
+`forRoot()` runs. A missing `MindLoggerService<name>` provider at bootstrap is almost always this
+ordering problem, not a typo. Tests reproduce the setup by calling `createMindLoggerProviders()`
+inside `beforeEach` (see `mind-logger.service.spec.ts`).
+
+`MindLoggerService` is `Scope.TRANSIENT` and lazy: `loggerService` is undefined until `setModule()`
+builds the winston logger, and every method uses `?.`, so logging before `setModule()` is a silent
+no-op. `MindLoggerFactory` writes to `logs/<module>.log` **relative to `process.cwd()`** and switches
+the level to `debug` when `process.env.DEBUG` is set. `logPrefix(method, infos)` builds the
+`pid|method#info1;info2` string that every call site passes as `prefix`.
+
+### `mind-helpers/error.helper.ts`
+
+`tsconfig.json` sets `useUnknownInCatchVariables: true`, so `catch (e)` is `unknown`. The convention
+in this repo is `const err = toError(e)` before touching `.message`/`.stack` or handing the value to
+the logger.
+
+- `toError(value): ThrownError` — returns the same instance when it already is an `Error` (subclasses
+  and driver-attached fields survive); otherwise builds an `Error` from `message`, copying `code`.
+  `ThrownError` widens `code` to `string | number` so Mongo's `11000` and Node/axios' `ECONNREFUSED`
+  are readable without a cast.
+- `MindError(code, message, { cause, context })` — the app-level error; its own fields serialize,
+  unlike a plain `Error`, whose `name`/`message` are non-enumerable and stringify to `{}`.
+- `jsonError(err)` — shapes a value for logging and **strips auth headers** (`Authorization`,
+  `X-API-KEY`, `Apikey`, `x-api-key`, `WPS-API-KEY`) from axios errors. It deletes them from the
+  object it was given, not from a copy — a deliberate, test-asserted side effect. Anything not an
+  axios error is passed through unchanged.
+- Known limitation, asserted in `mind-logger.service.spec.ts`: `MindLoggerService.error()` calls
+  `JSON.stringify(jsonError(err))` without circular-reference handling, so logging a circular object
+  throws. `toError()` itself is safe. If that is ever fixed, flip the test that expects the throw.
+
+### `mind-graphql` + `mind-mongoose`
+
+`GraphqlAuthJwksService` and `GraphqlAuthGatewayService` are two interchangeable `GqlOptionsFactory`
+implementations for Apollo Federation 2. Both require the consumer to provide a `REDIS_CLIENT`
+provider (an `ioredis` client) and both build the same request context
+(`mindUserId`, `mindUserRoles`, `mindSessionExpiresIn`) — the JWKS one by verifying the `Bearer`
+token against a JWKS document fetched from `process.env.JWKS_URL` and cached in redis under
+`JWKS_PUBLIC_KEY` for a day; the gateway one by trusting the `mind-user-id` / `mind-user-roles` /
+`mind-session-expires-in` headers already injected upstream. Use the gateway variant behind the
+router, the JWKS variant at the edge. On failure both return `undefined` instead of throwing, which
+leaves the resolvers with no context.
+
+`mind-mongoose/helpers/query.helper.ts` translates the GraphQL input types from
+`mind-graphql/entities/query.entities.ts` into a Mongoose filter/options pair, so the two evolve
+together: a new `OperationEnum` member needs a matching `case` in `getQuery`, and a new
+`*Value`/`*Values` field needs an entry in the `isNullOrUndefined` chain (order matters — the first
+non-null wins). `getOptions` defaults to `skip: 0, limit: 100` when no options are given, but honours
+the GraphQL defaults (`limit: 10`, sort by `updatedAt` desc) when they are.
+
+## Conventions and gotchas
+
+- **Code is English only**, per the "Idioma" section of the README: identifiers, file names, comments,
+  commit messages, branch names, log/error strings and test descriptions. `src/` is already fully in
+  English; the README is the one document written in pt-BR.
+- Prettier config is duplicated in `.prettierrc` and inline in `.eslintrc.js` — edit both.
+  Single quotes, 120 columns, trailing commas, 2 spaces.
+- `build` runs plain `tsc`, which picks up `tsconfig.json`, **not** `tsconfig.build.json`. Spec files
+  are therefore compiled into `dist/`, and `tsconfig.build.json` is effectively dead config.
+- The `lint` script's `src/**/*.ts` is expanded by bash with `globstar` off, i.e. it means `src/*/*.ts`.
+  `src/index.ts`, `src/mind-graphql/entities/` and `src/mind-mongoose/` are silently **not linted**.
+  Pass explicit paths to `eslint` when checking those.
+- `strictNullChecks` and `noImplicitAny` are off, so absent null checks are not compiler errors here
+  even though they would be in the consuming services.
+- Running the tests writes real log files to `logs/` (the "with the real winston logger" suite is
+  intentionally not mocked); `logs/` is gitignored.
+- `test/` exists but is empty — specs live next to the code as `*.spec.ts`.
+- Dependabot opens PRs against `develop`; `master` is the release branch that carries the tags.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,196 @@
   <a href="http://www.multiplan.com.br/" target="blank"><img width="300" src="https://github.com/user-attachments/assets/7b892075-a937-4651-8d73-b6545d8fcf08" alt="Multi Logo" /></a>
 </p>
 
-## Description
+## Descrição
+
+Biblioteca interna de apoio dos serviços MIND, escrita em NestJS. Não é uma aplicação: não tem
+`main.ts` nem servidor HTTP — só o que é compartilhado entre os `mind-api-*` / `multi-api-*`:
+
+| Módulo | O que oferece |
+| --- | --- |
+| `mind-logger` | logger baseado em winston, com escopo por módulo (`MindLoggerModule`, `MindLoggerService`, `@MindLogger()`, `logPrefix()`) |
+| `mind-helpers` | `MindError`, `toError()`, `jsonError()` e `isNullOrUndefined()` |
+| `mind-graphql` | `GraphqlAuthJwksService` e `GraphqlAuthGatewayService` (Apollo Federation 2) e os *input types* de consulta |
+| `mind-mongoose` | `getQuery()` / `getOptions()`, que traduzem os *inputs* GraphQL em filtro e opções do Mongoose |
+
+Tudo o que é público passa pelo *barrel* `src/index.ts`: um arquivo novo só fica visível para os
+serviços quando é reexportado lá.
+
+## Idioma
+
+Este README é o único documento em português. **O código é em inglês** — identificadores, nomes de
+arquivos e diretórios, comentários e JSDoc, mensagens de log e de erro, descrições de teste, mensagens
+de commit, nomes de branch e títulos de pull request.
+
+O código em `src/` já está todo em inglês — mantenha assim.
+
+## Requisitos
+
+- **Node v20.15.1**, a versão fixada no `.nvmrc` (a configuração de debug do VS Code aponta para esse
+  caminho exato dentro do `$NVM_DIR`).
+- **yarn 1.x** (clássico) — o `yarn.lock` do repositório é v1.
+- Acesso de leitura à organização `Multiplan-MIND` no GitHub, já que a instalação é feita pela URL do
+  git, não por um registry.
+
+## Clone e instalação
+
+```bash
+git clone https://github.com/Multiplan-MIND/mind-api-helpers.git
+cd mind-api-helpers
+nvm use          # respeita o .nvmrc
+yarn install
+```
+
+O `yarn install` **já compila o `dist/`**, por conta do ciclo declarado no `package.json`:
+
+- `preinstall: yarn --ignore-scripts` instala a árvore de dependências incluindo as `devDependencies`,
+  garantindo que o `typescript` exista;
+- `postinstall: yarn build` compila `src/` em `dist/`, que é o que `main` e `types` apontam.
+
+Isso existe porque o `dist/` não é versionado (está no `.gitignore`) e os serviços instalam esta
+biblioteca direto do git — sem esse ciclo, o consumidor receberia o pacote sem código compilado.
+
+## Scripts
+
+| Comando | O que faz |
+| --- | --- |
+| `yarn build` | `tsc` gerando `dist/` (o `prebuild` limpa a pasta com `rimraf`) |
+| `yarn test` | jest, configuração em `jest.config.json` (`testRegex: .spec.ts$`) |
+| `yarn lint` | eslint; o prettier roda como regra do eslint |
+| `yarn lint-autofix` | o mesmo, com `--fix` |
+
+### Testes
+
+Os testes ficam ao lado do código, como `*.spec.ts` (a pasta `test/` existe, mas está vazia).
+
+```bash
+yarn test                                   # tudo
+yarn test src/mind-helpers                  # um diretório
+yarn test -t 'should preserve subclasses'   # um teste pelo nome
+yarn test --watch
+yarn test --coverage
+```
+
+O VS Code tem a configuração de debug **"API Helpers - Jest"** em `.vscode/launch.json`.
+
+A suíte `with the real winston logger` roda com o winston de verdade, de propósito, então rodar os
+testes **escreve arquivos em `logs/`** (pasta ignorada pelo git).
+
+### Lint
+
+Atenção ao script: o padrão `src/**/*.ts` é expandido pelo bash com `globstar` desligado, ou seja,
+equivale a `src/*/*.ts`. Na prática, `src/index.ts`, `src/mind-graphql/entities/` e `src/mind-mongoose/`
+**não são verificados**. Para checá-los, passe o caminho explicitamente:
+
+```bash
+npx eslint src/index.ts src/mind-mongoose/**/*.ts
+```
+
+O estilo é o do `.prettierrc` — aspas simples, 120 colunas, vírgula final, indentação de 2 espaços.
+A mesma configuração está duplicada dentro do `.eslintrc.js`: ao mudar uma, mude a outra.
+
+## Uso em um serviço
+
+A dependência é declarada pela URL do git, fixada em uma tag:
+
+```json
+"dependencies": {
+  "mind-api-helpers": "https://github.com/Multiplan-MIND/mind-api-helpers.git#1.4.0"
+}
+```
+
+Durante o desenvolvimento de uma alteração também se aponta para uma branch
+(`...mind-api-helpers.git#feature/minha-branch`), para validar contra o serviço antes de gerar a tag.
+
+### Logger
+
+`MindLoggerModule.forRoot()` precisa ser importado em cada módulo que injeta o logger:
+
+```ts
+@Module({
+  imports: [MindLoggerModule.forRoot()],
+  providers: [MinhaService],
+})
+export class MeuModule {}
+
+@Injectable()
+export class MinhaService {
+  constructor(@MindLogger('MinhaService') private logger: MindLoggerService) {}
+
+  async salvar() {
+    const _log = logPrefix('salvar', ['id-123']);
+    try {
+      this.logger.info('Saving', _log);
+    } catch (e) {
+      const err = toError(e);
+      this.logger.error(`Error saving: ${err.message}`, _log, err);
+    }
+  }
+}
+```
+
+Dois detalhes que costumam gerar dúvida:
+
+- O `@MindLogger('Nome')` registra o nome em uma lista no momento em que a classe é carregada, e o
+  `forRoot()` transforma essa lista em providers. Se a classe decorada ainda não tiver sido importada
+  quando o `forRoot()` roda, o provider não é criado e o Nest reclama de `MindLoggerService<Nome>`
+  ausente — quase sempre é ordem de importação, não erro de digitação.
+- O logger grava em `logs/<módulo>.log` **relativo ao diretório de execução** do processo.
+
+### GraphQL
+
+`GraphqlAuthJwksService` e `GraphqlAuthGatewayService` são duas implementações intercambiáveis de
+`GqlOptionsFactory` para Apollo Federation 2. As duas montam o mesmo contexto de requisição
+(`mindUserId`, `mindUserRoles`, `mindSessionExpiresIn`):
+
+- **JWKS** — valida o token `Bearer` contra o JWKS baixado de `JWKS_URL`, com a chave pública em cache
+  no redis. Use na borda, onde o token chega do cliente.
+- **Gateway** — confia nos headers `mind-user-id`, `mind-user-roles` e `mind-session-expires-in` já
+  injetados por quem está na frente. Use atrás do router.
+
+Ambas exigem que o serviço forneça um provider `REDIS_CLIENT` (um client `ioredis`) e, em caso de
+falha, retornam `undefined` em vez de lançar — os resolvers ficam sem contexto.
+
+```ts
+GraphQLModule.forRootAsync<ApolloFederationDriverConfig>({
+  driver: ApolloFederationDriver,
+  imports: [CacheModule, MindLoggerModule.forRoot()],
+  useClass: process.env.GRAPHQL_SERVICE === 'jwks' ? GraphqlAuthJwksService : GraphqlAuthGatewayService,
+})
+```
+
+## Variáveis de ambiente
+
+A biblioteca lê apenas duas — quem as define é o serviço que a consome (ela não carrega `.env`):
+
+| Variável | Efeito |
+| --- | --- |
+| `DEBUG` | qualquer valor definido sobe o nível do logger de `info` para `debug` |
+| `JWKS_URL` | endereço do documento JWKS usado pelo `GraphqlAuthJwksService` |
+
+O acesso ao redis não vem de variável: chega pelo provider `REDIS_CLIENT`, configurado no serviço.
+A chave pública fica em cache sob `JWKS_PUBLIC_KEY` por um dia.
+
+## Dependências e ambientes
+
+Quase tudo o que o código importa em tempo de execução (`mongoose`, `ioredis`, `jsonwebtoken`,
+`jwk-to-pem`, `graphql-type-json`, `winston`, `nest-winston`, `@nestjs/*`, `@apollo/server`) está em
+`devDependencies`, e só `@nestjs/common` e `winston` estão declarados como `peerDependencies`. Em
+produção essas bibliotecas são resolvidas no `node_modules` **do serviço**, não no desta biblioteca —
+então subir uma versão aqui pode divergir do que os serviços instalam. Vale conferir o serviço antes
+de mexer nas versões.
+
+O `axios`, usado por `error.helper.ts` e pelo serviço JWKS, não está declarado: ele só aparece porque
+a única entrada em `dependencies`, o pacote descontinuado `@types/axios`, depende de `axios: "*"`.
+
+## Versionamento e publicação
+
+Não há publicação em registry. Liberar uma versão é:
+
+1. subir o campo `version` do `package.json`;
+2. criar a tag correspondente no commit em `master` — o padrão atual é sem o prefixo `v` (`1.4.0`);
+   existe um `v1.1.0` antigo, que é exceção;
+3. atualizar o `#tag` no `package.json` de cada serviço que consome a biblioteca.
+
+`master` é a branch de release e carrega as tags; `develop` recebe a integração e é o alvo dos PRs do
+dependabot.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <p align="center">
-  <a href="http://www.multiplan.com.br/" target="blank"><img src="https://mts-github-wiki.s3.amazonaws.com/mind/multiplan-logo.png" width="
-  300" alt="Multi Logo" /></a>
+  <a href="http://www.multiplan.com.br/" target="blank"><img width="300" src="https://github.com/user-attachments/assets/7b892075-a937-4651-8d73-b6545d8fcf08" alt="Multi Logo" /></a>
 </p>
 
 ## Description
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mind-api-helpers",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "description": "",
   "author": "https://github.com/Multiplan-MIND/",
   "private": true,

--- a/src/mind-graphql/graphql-auth-gateway.service.ts
+++ b/src/mind-graphql/graphql-auth-gateway.service.ts
@@ -8,6 +8,7 @@ import GraphQLJSON from 'graphql-type-json';
 import { MindLoggerService } from '../mind-logger/mind-logger.service';
 import { MindLogger } from '../mind-logger/mind-logger.decorator';
 import { logPrefix } from '../mind-logger/mind-logger.util';
+import { toError } from '../mind-helpers/error.helper';
 
 @Injectable()
 export class GraphqlAuthGatewayService implements GqlOptionsFactory<ApolloFederationDriverConfig> {
@@ -40,7 +41,8 @@ export class GraphqlAuthGatewayService implements GqlOptionsFactory<ApolloFedera
         ctx.mindSessionExpiresIn = new Date(req?.headers?.['mind-session-expires-in']);
       }
     } catch (e) {
-      this.logger.error(`Error setting context: ${e.message}`, _log, e);
+      const err = toError(e);
+      this.logger.error(`Error setting context: ${err.message}`, _log, err);
       return;
     }
     return ctx;

--- a/src/mind-graphql/graphql-auth-jwks.service.ts
+++ b/src/mind-graphql/graphql-auth-jwks.service.ts
@@ -12,6 +12,7 @@ import GraphQLJSON from 'graphql-type-json';
 import { MindLoggerService } from '../mind-logger/mind-logger.service';
 import { MindLogger } from '../mind-logger/mind-logger.decorator';
 import { logPrefix } from '../mind-logger/mind-logger.util';
+import { toError } from '../mind-helpers/error.helper';
 
 @Injectable()
 export class GraphqlAuthJwksService implements GqlOptionsFactory<ApolloFederationDriverConfig> {
@@ -78,13 +79,15 @@ export class GraphqlAuthJwksService implements GqlOptionsFactory<ApolloFederatio
               }
             }
           } catch (e) {
-            this.logger.error(`Error setting context: ${e.message}`, _log, e);
+            const err = toError(e);
+            this.logger.error(`Error setting context: ${err.message}`, _log, err);
             return;
           }
         }
       }
     } catch (e) {
-      this.logger.error(`Error setting context: ${e.message}`, _log, e);
+      const err = toError(e);
+      this.logger.error(`Error setting context: ${err.message}`, _log, err);
       return;
     }
     return ctx;

--- a/src/mind-helpers/error.helper.spec.ts
+++ b/src/mind-helpers/error.helper.spec.ts
@@ -1,0 +1,53 @@
+import { MindError, jsonError, toError } from './error.helper';
+
+describe('error.helper', () => {
+  describe('toError', () => {
+    it('should return the same instance when the value already is an Error', () => {
+      const original = new Error('Errorrrr');
+      expect(toError(original)).toBe(original);
+    });
+
+    it('should preserve subclasses of Error', () => {
+      const original = new MindError('loyalty.exists', 'Loyalty already exists');
+      const error = toError(original);
+      expect(error).toBe(original);
+      expect(error).toBeInstanceOf(MindError);
+    });
+
+    it('should use the string thrown as message', () => {
+      expect(toError('Errorrrr').message).toBe('Errorrrr');
+    });
+
+    it('should use the message of a plain object', () => {
+      expect(toError({ code: 11000, message: 'duplicate key' }).message).toBe('duplicate key');
+    });
+
+    it('should serialize objects without message', () => {
+      expect(toError({ code: 11000 }).message).toBe('{"code":11000}');
+    });
+
+    it('should not throw on circular references', () => {
+      const circular: Record<string, unknown> = { code: 11000 };
+      circular.self = circular;
+      expect(toError(circular)).toBeInstanceOf(Error);
+    });
+
+    it('should handle values without serialization', () => {
+      expect(toError(undefined).message).toBe('undefined');
+      expect(toError(null).message).toBe('null');
+    });
+  });
+
+  describe('jsonError', () => {
+    it('should accept values that are not Error', () => {
+      expect(() => JSON.stringify(jsonError('Errorrrr'))).not.toThrow();
+    });
+
+    it('should preserve the fields of a plain object', () => {
+      expect(jsonError({ code: 11000, message: 'duplicate key' })).toEqual({
+        code: 11000,
+        message: 'duplicate key',
+      });
+    });
+  });
+});

--- a/src/mind-helpers/error.helper.spec.ts
+++ b/src/mind-helpers/error.helper.spec.ts
@@ -22,6 +22,26 @@ describe('error.helper', () => {
       expect(toError({ code: 11000, message: 'duplicate key' }).message).toBe('duplicate key');
     });
 
+    it('should expose the code of a mongo error without a cast', () => {
+      const mongoLike: Error & { code?: number } = new Error('E11000 duplicate key error');
+      mongoLike.code = 11000;
+
+      const error = toError(mongoLike);
+
+      expect(error.code).toBe(11000);
+      expect(error).toBe(mongoLike);
+    });
+
+    it('should keep the code when normalizing a plain object', () => {
+      expect(toError({ code: 11000, message: 'duplicate key' }).code).toBe(11000);
+      expect(toError({ code: 'ECONNREFUSED', message: 'connect refused' }).code).toBe('ECONNREFUSED');
+    });
+
+    it('should leave the code undefined when there is none', () => {
+      expect(toError('Errorrrr').code).toBeUndefined();
+      expect(toError({ message: 'Errorrrr' }).code).toBeUndefined();
+    });
+
     it('should serialize objects without message', () => {
       expect(toError({ code: 11000 }).message).toBe('{"code":11000}');
     });

--- a/src/mind-helpers/error.helper.ts
+++ b/src/mind-helpers/error.helper.ts
@@ -48,7 +48,7 @@ export interface ThrownError extends Error {
 export function toError(value: unknown): ThrownError {
   if (value instanceof Error) return value;
 
-  // Libs que rejeitam com objeto simples (drivers, clients HTTP) normalmente trazem `message`
+  // Libs that reject with a plain object (drivers, HTTP clients) usually carry `message`
   const source = value as { message?: unknown; code?: unknown };
   if (typeof source?.message === 'string') {
     const error: ThrownError = new Error(source.message);

--- a/src/mind-helpers/error.helper.ts
+++ b/src/mind-helpers/error.helper.ts
@@ -26,7 +26,34 @@ export class MindError extends Error {
   }
 }
 
-export function jsonError(err: Error) {
+/**
+ * Normaliza para `Error` o valor capturado em um `catch`.
+ *
+ * Em JavaScript qualquer valor pode ser lançado, por isso o TypeScript tipa a variável do `catch`
+ * como `unknown`. Use este helper antes de acessar `.message`/`.stack` ou de repassar o valor para
+ * algo que espere um `Error`.
+ */
+export function toError(value: unknown): Error {
+  if (value instanceof Error) return value;
+
+  // Libs que rejeitam com objeto simples (drivers, clients HTTP) normalmente trazem `message`
+  const message = (value as { message?: unknown })?.message;
+  if (typeof message === 'string') return new Error(message);
+
+  return new Error(stringifyValue(value));
+}
+
+function stringifyValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try {
+    // `JSON.stringify` devolve undefined para `undefined` e lança em referência circular
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function jsonError(err: unknown) {
   let json = {};
   if (axios.isAxiosError(err)) {
     if (err?.response?.config) {
@@ -52,7 +79,8 @@ export function jsonError(err: Error) {
       stack: err.stack,
     };
   } else {
-    json = err;
+    // mantém o valor original: `Error` serializa como `{}`, mas objetos simples preservam os campos
+    json = err as object;
   }
   return json;
 }

--- a/src/mind-helpers/error.helper.ts
+++ b/src/mind-helpers/error.helper.ts
@@ -27,18 +27,34 @@ export class MindError extends Error {
 }
 
 /**
+ * Erro capturado em um `catch`, com as propriedades que drivers e clients costumam anexar.
+ *
+ * `code` cobre tanto o número do MongoDB (11000 é chave duplicada) quanto os códigos em texto do
+ * Node e do axios ('ECONNREFUSED', 'ERR_BAD_REQUEST'), sem precisar de cast no ponto de uso.
+ * Para os campos de um erro axios (`response`, `config`), use `axios.isAxiosError(e)`, que estreita
+ * o tipo corretamente.
+ */
+export interface ThrownError extends Error {
+  code?: string | number;
+}
+
+/**
  * Normaliza para `Error` o valor capturado em um `catch`.
  *
  * Em JavaScript qualquer valor pode ser lançado, por isso o TypeScript tipa a variável do `catch`
  * como `unknown`. Use este helper antes de acessar `.message`/`.stack` ou de repassar o valor para
  * algo que espere um `Error`.
  */
-export function toError(value: unknown): Error {
+export function toError(value: unknown): ThrownError {
   if (value instanceof Error) return value;
 
   // Libs que rejeitam com objeto simples (drivers, clients HTTP) normalmente trazem `message`
-  const message = (value as { message?: unknown })?.message;
-  if (typeof message === 'string') return new Error(message);
+  const source = value as { message?: unknown; code?: unknown };
+  if (typeof source?.message === 'string') {
+    const error: ThrownError = new Error(source.message);
+    if (typeof source.code === 'string' || typeof source.code === 'number') error.code = source.code;
+    return error;
+  }
 
   return new Error(stringifyValue(value));
 }

--- a/src/mind-helpers/error.helper.ts
+++ b/src/mind-helpers/error.helper.ts
@@ -27,23 +27,23 @@ export class MindError extends Error {
 }
 
 /**
- * Erro capturado em um `catch`, com as propriedades que drivers e clients costumam anexar.
+ * An error caught in a `catch`, with properties that drivers and HTTP clients typically attach.
  *
- * `code` cobre tanto o número do MongoDB (11000 é chave duplicada) quanto os códigos em texto do
- * Node e do axios ('ECONNREFUSED', 'ERR_BAD_REQUEST'), sem precisar de cast no ponto de uso.
- * Para os campos de um erro axios (`response`, `config`), use `axios.isAxiosError(e)`, que estreita
- * o tipo corretamente.
+ * `code` covers both MongoDB error numbers (11000 is duplicate key) and text codes from
+ * Node and axios ('ECONNREFUSED', 'ERR_BAD_REQUEST'), without needing a cast at the call site.
+ * For axios error fields (`response`, `config`), use `axios.isAxiosError(e)`, which narrows
+ * the type correctly.
  */
 export interface ThrownError extends Error {
   code?: string | number;
 }
 
 /**
- * Normaliza para `Error` o valor capturado em um `catch`.
+ * Normalizes the value caught in a `catch` to an `Error`.
  *
- * Em JavaScript qualquer valor pode ser lançado, por isso o TypeScript tipa a variável do `catch`
- * como `unknown`. Use este helper antes de acessar `.message`/`.stack` ou de repassar o valor para
- * algo que espere um `Error`.
+ * In JavaScript any value can be thrown, so TypeScript types the `catch` variable
+ * as `unknown`. Use this helper before accessing `.message`/`.stack` or passing the value to
+ * something that expects an `Error`.
  */
 export function toError(value: unknown): ThrownError {
   if (value instanceof Error) return value;
@@ -62,7 +62,7 @@ export function toError(value: unknown): ThrownError {
 function stringifyValue(value: unknown): string {
   if (typeof value === 'string') return value;
   try {
-    // `JSON.stringify` devolve undefined para `undefined` e lança em referência circular
+    // `JSON.stringify` returns undefined for `undefined` and throws on circular references
     return JSON.stringify(value) ?? String(value);
   } catch {
     return String(value);
@@ -95,7 +95,7 @@ export function jsonError(err: unknown) {
       stack: err.stack,
     };
   } else {
-    // mantém o valor original: `Error` serializa como `{}`, mas objetos simples preservam os campos
+    // preserves the original value: `Error` serializes as `{}`, but plain objects preserve their fields
     json = err as object;
   }
   return json;

--- a/src/mind-logger/mind-logger.service.spec.ts
+++ b/src/mind-logger/mind-logger.service.spec.ts
@@ -1,10 +1,23 @@
+import { LoggerService } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+
 import { createMindLoggerProviders } from './mind-logger.providers';
 import { MindLoggerService } from './mind-logger.service';
 import { logPrefix } from './mind-logger.util';
+import { MindError } from '../mind-helpers/error.helper';
+
+type WinstonMock = { log: jest.Mock; error: jest.Mock; warn: jest.Mock; debug: jest.Mock; verbose: jest.Mock };
 
 describe('MindLoggerService', () => {
+  const prefix = logPrefix('TestMethod', ['info-1', 'info-2']);
+
   let mindLoggerService: MindLoggerService;
+  let winston: WinstonMock;
+
+  const lastError = () => {
+    const [message, stack, context] = winston.error.mock.calls[winston.error.mock.calls.length - 1];
+    return { message, stack, context };
+  };
 
   beforeEach(async () => {
     const modulesLoggerProviders = createMindLoggerProviders();
@@ -13,19 +26,192 @@ describe('MindLoggerService', () => {
     }).compile();
 
     mindLoggerService = await moduleRef.resolve<MindLoggerService>(MindLoggerService);
+    mindLoggerService.setModule('TestModule');
+
+    // troca o winston por mocks para inspecionar o que o serviço repassa adiante
+    winston = { log: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn(), verbose: jest.fn() };
+    mindLoggerService['loggerService'] = winston as unknown as LoggerService;
   });
 
-  describe('check log', () => {
-    it('should return', async () => {
-      mindLoggerService.setModule('TestModule');
-      const prefix = logPrefix('TestMethod', ['info-1', 'info-2']);
-      mindLoggerService.info('Test Info without prefix');
-      mindLoggerService.error('Test Error without prefix', null, new Error('Errorrrr'));
+  describe('error with an Error', () => {
+    it('should append the serialized error and forward the stack', () => {
+      const err = new Error('Errorrrr');
+
+      mindLoggerService.error('Error in save', prefix, err);
+
+      // Error tem name/message como propriedades não enumeráveis, por isso serializa como {}
+      expect(lastError().message).toBe('Error in save | {}');
+      expect(lastError().stack).toBe(err.stack);
+      expect(lastError().context).toEqual({ module: 'TestModule', prefix });
+    });
+
+    it('should keep the fields of a MindError', () => {
+      const err = new MindError('loyalty.exists', 'Loyalty already exists', { context: { plate: 'ABC1234' } });
+
+      mindLoggerService.error('Error in save', prefix, err);
+
+      expect(lastError().message).toContain('"code":"loyalty.exists"');
+      expect(lastError().message).toContain('"plate":"ABC1234"');
+      expect(lastError().stack).toBe(err.stack);
+    });
+  });
+
+  describe('error with a value that is not an Error', () => {
+    it('should accept a thrown string', () => {
+      mindLoggerService.error('Error in save', prefix, 'Errorrrr');
+
+      expect(lastError().message).toBe('Error in save | "Errorrrr"');
+      expect(lastError().stack).toBeUndefined();
+    });
+
+    it('should keep every field of a plain object', () => {
+      const err = { code: 11000, message: 'duplicate key', keyValue: { cpf: '00000000000' } };
+
+      mindLoggerService.error('Error in save', prefix, err);
+
+      expect(lastError().message).toContain('"code":11000');
+      expect(lastError().message).toContain('"message":"duplicate key"');
+      expect(lastError().message).toContain('"cpf":"00000000000"');
+      expect(lastError().stack).toBeUndefined();
+    });
+
+    it('should accept a number', () => {
+      mindLoggerService.error('Error in save', prefix, 404);
+
+      expect(lastError().message).toBe('Error in save | 404');
+    });
+
+    it('should forward the stack of an object that carries one', () => {
+      const err = { message: 'Errorrrr', stack: 'Error: Errorrrr\n    at somewhere' };
+
+      mindLoggerService.error('Error in save', prefix, err);
+
+      expect(lastError().stack).toBe(err.stack);
+    });
+
+    it('should not append anything when there is no error', () => {
+      mindLoggerService.error('Error in save', prefix);
+
+      expect(lastError().message).toBe('Error in save');
+      expect(lastError().stack).toBeUndefined();
+    });
+
+    it('should ignore null and undefined', () => {
+      mindLoggerService.error('Error in save', prefix, null);
+      expect(lastError().message).toBe('Error in save');
+
+      mindLoggerService.error('Error in save', prefix, undefined);
+      expect(lastError().message).toBe('Error in save');
+    });
+
+    it('should ignore falsy values, since the check is truthiness based', () => {
+      mindLoggerService.error('Error in save', prefix, 0);
+      expect(lastError().message).toBe('Error in save');
+
+      mindLoggerService.error('Error in save', prefix, '');
+      expect(lastError().message).toBe('Error in save');
+    });
+
+    // limitação conhecida: o `JSON.stringify` do error() não trata referência circular, então logar
+    // derruba o fluxo. Se o serviço passar a tratar o caso, inverta para `not.toThrow()`.
+    it('should throw on a circular reference, which is a known limitation', () => {
+      const err: Record<string, unknown> = { code: 11000 };
+      err.self = err;
+
+      expect(() => mindLoggerService.error('Error in save', prefix, err)).toThrow(TypeError);
+    });
+  });
+
+  describe('error with an axios error', () => {
+    const buildAxiosError = () => ({
+      isAxiosError: true,
+      name: 'AxiosError',
+      message: 'Request failed with status code 401',
+      stack: 'AxiosError: Request failed with status code 401\n    at somewhere',
+      code: 'ERR_BAD_REQUEST',
+      response: {
+        status: 401,
+        statusText: 'Unauthorized',
+        data: { error: 'invalid' },
+        headers: {},
+        config: {
+          url: '/loyalty',
+          headers: { Authorization: 'valor-sensivel-nao-deve-vazar', 'X-API-KEY': 'chave-nao-deve-vazar' },
+        },
+      },
+    });
+
+    it('should log the response without the sensitive headers', () => {
+      mindLoggerService.error('Error in save', prefix, buildAxiosError());
+
+      expect(lastError().message).toContain('"status":401');
+      expect(lastError().message).toContain('"code":"ERR_BAD_REQUEST"');
+      expect(lastError().message).not.toContain('valor-sensivel-nao-deve-vazar');
+      expect(lastError().message).not.toContain('chave-nao-deve-vazar');
+    });
+
+    it('should forward the stack even though it is not an Error instance', () => {
+      const err = buildAxiosError();
+
+      mindLoggerService.error('Error in save', prefix, err);
+
+      expect(lastError().stack).toBe(err.stack);
+    });
+
+    it('should strip the sensitive headers from the error object itself', () => {
+      const err = buildAxiosError();
+
+      mindLoggerService.error('Error in save', prefix, err);
+
+      // efeito colateral de jsonError: os headers são apagados do objeto recebido, não de uma cópia
+      expect(err.response.config.headers).toEqual({});
+    });
+  });
+
+  describe('other levels', () => {
+    it('should forward info to log', () => {
       mindLoggerService.info('Test Info', prefix);
-      mindLoggerService.error('Test Error', prefix, new Error('Errorrrr'));
+
+      expect(winston.log).toHaveBeenCalledWith('Test Info', { module: 'TestModule', prefix });
+    });
+
+    it('should forward warn', () => {
       mindLoggerService.warn('Test Warn', prefix);
+
+      expect(winston.warn).toHaveBeenCalledWith('Test Warn', { module: 'TestModule', prefix });
+    });
+
+    it('should forward debug and verbose', () => {
       mindLoggerService.debug('Test Debug', prefix);
       mindLoggerService.verbose('Test Verbose', prefix);
+
+      expect(winston.debug).toHaveBeenCalledWith('Test Debug', { module: 'TestModule', prefix });
+      expect(winston.verbose).toHaveBeenCalledWith('Test Verbose', { module: 'TestModule', prefix });
+    });
+
+    it('should work without a prefix', () => {
+      mindLoggerService.info('Test Info without prefix');
+
+      expect(winston.log).toHaveBeenCalledWith('Test Info without prefix', { module: 'TestModule', prefix: undefined });
+    });
+  });
+
+  describe('with the real winston logger', () => {
+    it('should not throw on any level', () => {
+      const service = mindLoggerService;
+      service.setModule('TestModule');
+
+      expect(() => {
+        service.info('Test Info without prefix');
+        service.error('Test Error without prefix', null, new Error('Errorrrr'));
+        service.info('Test Info', prefix);
+        service.error('Test Error', prefix, new Error('Errorrrr'));
+        service.error('Test Error with a string', prefix, 'Errorrrr');
+        service.error('Test Error with an object', prefix, { code: 11000 });
+        service.warn('Test Warn', prefix);
+        service.debug('Test Debug', prefix);
+        service.verbose('Test Verbose', prefix);
+      }).not.toThrow();
     });
   });
 });

--- a/src/mind-logger/mind-logger.service.spec.ts
+++ b/src/mind-logger/mind-logger.service.spec.ts
@@ -136,7 +136,7 @@ describe('MindLoggerService', () => {
         headers: {},
         config: {
           url: '/loyalty',
-          headers: { Authorization: 'valor-sensivel-nao-deve-vazar', 'X-API-KEY': 'chave-nao-deve-vazar' },
+          headers: { Authorization: 'sensitive-value-must-not-leak', 'X-API-KEY': 'api-key-must-not-leak' },
         },
       },
     });
@@ -146,8 +146,8 @@ describe('MindLoggerService', () => {
 
       expect(lastError().message).toContain('"status":401');
       expect(lastError().message).toContain('"code":"ERR_BAD_REQUEST"');
-      expect(lastError().message).not.toContain('valor-sensivel-nao-deve-vazar');
-      expect(lastError().message).not.toContain('chave-nao-deve-vazar');
+      expect(lastError().message).not.toContain('sensitive-value-must-not-leak');
+      expect(lastError().message).not.toContain('api-key-must-not-leak');
     });
 
     it('should forward the stack even though it is not an Error instance', () => {

--- a/src/mind-logger/mind-logger.service.spec.ts
+++ b/src/mind-logger/mind-logger.service.spec.ts
@@ -28,7 +28,7 @@ describe('MindLoggerService', () => {
     mindLoggerService = await moduleRef.resolve<MindLoggerService>(MindLoggerService);
     mindLoggerService.setModule('TestModule');
 
-    // troca o winston por mocks para inspecionar o que o serviço repassa adiante
+    // replaces winston with mocks to inspect what the service forwards
     winston = { log: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn(), verbose: jest.fn() };
     mindLoggerService['loggerService'] = winston as unknown as LoggerService;
   });
@@ -39,7 +39,7 @@ describe('MindLoggerService', () => {
 
       mindLoggerService.error('Error in save', prefix, err);
 
-      // Error tem name/message como propriedades não enumeráveis, por isso serializa como {}
+      // Error has name/message as non-enumerable properties, so it serializes as {}
       expect(lastError().message).toBe('Error in save | {}');
       expect(lastError().stack).toBe(err.stack);
       expect(lastError().context).toEqual({ module: 'TestModule', prefix });
@@ -112,8 +112,8 @@ describe('MindLoggerService', () => {
       expect(lastError().message).toBe('Error in save');
     });
 
-    // limitação conhecida: o `JSON.stringify` do error() não trata referência circular, então logar
-    // derruba o fluxo. Se o serviço passar a tratar o caso, inverta para `not.toThrow()`.
+    // known limitation: the `JSON.stringify` in error() does not handle circular references, so logging
+    // causes the flow to break. If the service handles this case, change to `not.toThrow()`.
     it('should throw on a circular reference, which is a known limitation', () => {
       const err: Record<string, unknown> = { code: 11000 };
       err.self = err;
@@ -163,7 +163,7 @@ describe('MindLoggerService', () => {
 
       mindLoggerService.error('Error in save', prefix, err);
 
-      // efeito colateral de jsonError: os headers são apagados do objeto recebido, não de uma cópia
+      // side effect of jsonError: headers are deleted from the received object, not from a copy
       expect(err.response.config.headers).toEqual({});
     });
   });

--- a/src/mind-logger/mind-logger.service.ts
+++ b/src/mind-logger/mind-logger.service.ts
@@ -13,9 +13,9 @@ export class MindLoggerService {
   info(message: string, prefix?: string) {
     this.loggerService?.log(message, { module: this.module, prefix });
   }
-  error(message: string, prefix?: string, err?: Error) {
+  error(message: string, prefix?: string, err?: unknown) {
     if (err) message += ` | ${JSON.stringify(jsonError(err))}`;
-    this.loggerService?.error(message, err?.stack, { module: this.module, prefix });
+    this.loggerService?.error(message, (err as Error)?.stack, { module: this.module, prefix });
   }
   warn(message: string, prefix?: string) {
     this.loggerService?.warn(message, { module: this.module, prefix });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
+    "rootDir": "./src",
     "incremental": true,
     "skipLibCheck": true,
     "types": ["jest", "node"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "skipLibCheck": true,
     "strictNullChecks": false,
     "noImplicitAny": false,
+    "useUnknownInCatchVariables": true,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
+    "types": ["jest", "node"],
     "strictNullChecks": false,
     "noImplicitAny": false,
     "useUnknownInCatchVariables": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "incremental": true,
     "skipLibCheck": true,
     "types": ["jest", "node"],
     "strictNullChecks": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1774,7 +1774,7 @@ braces@~3.0.2:
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
-    fill-range "^7.1.1"
+    fill-range "^7.0.1"
 
 brorand@^1.1.0:
   version "1.1.0"
@@ -2550,13 +2550,6 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-fill-range@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
-  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
-  dependencies:
-    to-regex-range "^5.0.1"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -3820,7 +3813,7 @@ mongodb@~6.16.0:
     bson "^6.10.3"
     mongodb-connection-string-url "^3.0.0"
 
-mongoose@^8.14.0:
+mongoose@8.14.0:
   version "8.14.0"
   resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-8.14.0.tgz#62c56f6046bbf23b6447fc383bb62ab773c34580"
   integrity sha512-IxDxIUu42apE7oEknJK535xkQ6Gd7GKx/gNrNHY+vP4+ucVU2TOCWjVVW14Vc79y9DEEElzHDlTOuVNM8glUFA==


### PR DESCRIPTION
Since TS 4.4 the catch variable is typed as unknown, so passing it to MindLoggerService.error (err?: Error) fails to compile. Widening the parameter to unknown fixes all 79 call sites across the services without touching any of them.

- add toError(value: unknown): Error, safe for circular references
- jsonError accepts unknown; isAxiosError already narrows it
- keep the original value in jsonError so plain objects keep their fields
- use toError in the catch blocks of this repo
- enable useUnknownInCatchVariables to prevent regressions here